### PR TITLE
Add semantic versioning (semver) goal 

### DIFF
--- a/src/main/java/org/codehaus/mojo/versions/AbstractModuleVersionUpdaterMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/AbstractModuleVersionUpdaterMojo.java
@@ -1,0 +1,323 @@
+package org.codehaus.mojo.versions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.versions.api.PomHelper;
+import org.codehaus.mojo.versions.change.VersionChange;
+import org.codehaus.mojo.versions.change.VersionChanger;
+import org.codehaus.mojo.versions.change.VersionChangerFactory;
+import org.codehaus.mojo.versions.ordering.ReactorDepthComparator;
+import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
+import org.codehaus.mojo.versions.utils.ContextualLog;
+import org.codehaus.mojo.versions.utils.DelegatingContextualLog;
+import org.codehaus.mojo.versions.utils.RegexUtils;
+import org.codehaus.plexus.util.StringUtils;
+
+public abstract class AbstractModuleVersionUpdaterMojo extends AbstractVersionsUpdaterMojo {
+
+	protected static final String SNAPSHOT = "-SNAPSHOT";
+	/**
+	 * The groupId of the dependency/module to update.
+	 *
+	 * @since 1.2
+	 */
+	@Parameter(property = "groupId", defaultValue = "${project.groupId}")
+	private String groupId;
+	/**
+	 * The artifactId of the dependency/module to update.
+	 *
+	 * @since 1.2
+	 */
+	@Parameter(property = "artifactId", defaultValue = "${project.artifactId}")
+	private String artifactId;
+	/**
+	 * The version of the dependency/module to update.
+	 *
+	 * @since 1.2
+	 */
+	@Parameter(property = "oldVersion", defaultValue = "${project.version}")
+	private String oldVersion;
+	/**
+	 * Whether matching versions explicitly specified (as /project/version) in child modules should be updated.
+	 *
+	 * @since 1.3
+	 */
+	@Parameter(property = "updateMatchingVersions", defaultValue = "true")
+	protected boolean updateMatchingVersions;
+	/**
+	 * Whether to process the parent of the project. If not set will default to true.
+	 *
+	 * @since 1.3
+	 */
+	@Parameter(property = "processParent", defaultValue = "true")
+	private boolean processParent;
+	/**
+	 * Whether to process the project version. If not set will default to true.
+	 *
+	 * @since 1.3
+	 */
+	@Parameter(property = "processProject", defaultValue = "true")
+	private boolean processProject;
+	/**
+	 * Whether to process the dependencies section of the project. If not set will default to true.
+	 *
+	 * @since 1.3
+	 */
+	@Parameter(property = "processDependencies", defaultValue = "true")
+	private boolean processDependencies;
+	/**
+	 * Whether to process the plugins section of the project. If not set will default to true.
+	 *
+	 * @since 1.3
+	 */
+	@Parameter(property = "processPlugins", defaultValue = "true")
+	private boolean processPlugins;
+	/**
+	 * The changes to module coordinates. Guarded by this.
+	 */
+	private final transient List<VersionChange> sourceChanges = new ArrayList<VersionChange>();
+
+	private static String fixNullOrEmpty(String value, String defaultValue) {
+	    return StringUtils.isBlank( value ) ? defaultValue : value;
+	}
+
+	private synchronized void addChange(String groupId, String artifactId, String oldVersion, String newVersion) {
+	    if ( !newVersion.equals( oldVersion ) )
+	    {
+	        sourceChanges.add( new VersionChange( groupId, artifactId, oldVersion, newVersion ) );
+	    }
+	}
+
+	protected void setVersion(String newVersion) throws MojoExecutionException, MojoFailureException {
+		try
+	    {
+	        final MavenProject project =
+	            PomHelper.getLocalRoot( projectBuilder, getProject(), localRepository, null, getLog() );
+	
+	        getLog().info( "Local aggregation root: " + project.getBasedir() );
+	        Map<String, Model> reactorModels = PomHelper.getReactorModels( project, getLog() );
+	        final SortedMap<String, Model> reactor =
+	            new TreeMap<String, Model>( new ReactorDepthComparator( reactorModels ) );
+	        reactor.putAll( reactorModels );
+	
+	        // set of files to update
+	        final Set<File> files = new LinkedHashSet<File>();
+	
+	        getLog().info( "Processing change of " + groupId + ":" + artifactId + ":" + oldVersion + " -> "
+	            + newVersion );
+	        Pattern groupIdRegex =
+	            Pattern.compile( RegexUtils.convertWildcardsToRegex( fixNullOrEmpty( groupId, "*" ), true ) );
+	        Pattern artifactIdRegex =
+	            Pattern.compile( RegexUtils.convertWildcardsToRegex( fixNullOrEmpty( artifactId, "*" ), true ) );
+	        Pattern oldVersionIdRegex =
+	            Pattern.compile( RegexUtils.convertWildcardsToRegex( fixNullOrEmpty( oldVersion, "*" ), true ) );
+	        boolean found = false;
+	        for ( Model m : reactor.values() )
+	        {
+	            final String mGroupId = PomHelper.getGroupId( m );
+	            final String mArtifactId = PomHelper.getArtifactId( m );
+	            final String mVersion = PomHelper.getVersion( m );
+	            if ( groupIdRegex.matcher( mGroupId ).matches() && artifactIdRegex.matcher( mArtifactId ).matches()
+	                && oldVersionIdRegex.matcher( mVersion ).matches() && !newVersion.equals( mVersion ) )
+	            {
+	                found = true;
+	                // if the change is not one we have swept up already
+	                applyChange( project, reactor, files, mGroupId, m.getArtifactId(),
+	                             StringUtils.isBlank( oldVersion ) || "*".equals( oldVersion ) ? "" : m.getVersion(),
+	                            		 newVersion);
+	            }
+	        }
+	        if ( !found && RegexUtils.getWildcardScore(groupId) == 0
+	        		&& RegexUtils.getWildcardScore(artifactId) == 0
+	        		&& RegexUtils.getWildcardScore(oldVersion) == 0 )
+	        {
+	            applyChange( project, reactor, files, groupId, artifactId, oldVersion, newVersion );
+	        }
+	
+	        // now process all the updates
+	        for ( File file : files )
+	        {
+	            process( file );
+	        }
+	
+	    }
+	    catch ( IOException e )
+	    {
+	        throw new MojoExecutionException( e.getMessage(), e );
+	    }
+	}
+
+	public AbstractModuleVersionUpdaterMojo() {
+		super();
+	}
+
+	private void applyChange(MavenProject project, SortedMap<String, Model> reactor, Set<File> files, String groupId, String artifactId, String oldVersion, String newVersion) {
+	
+	    getLog().debug( "Applying change " + groupId + ":" + artifactId + ":" + oldVersion + " -> " + newVersion );
+	    // this is a triggering change
+	    addChange( groupId, artifactId, oldVersion, newVersion );
+	    // now fake out the triggering change
+	
+	    final Map.Entry<String, Model> current = PomHelper.getModelEntry( reactor, groupId, artifactId );
+	    current.getValue().setVersion( newVersion );
+	
+	    addFile( files, project, current.getKey() );
+	
+	    for ( Map.Entry<String, Model> sourceEntry : reactor.entrySet() )
+	    {
+	        final String sourcePath = sourceEntry.getKey();
+	        final Model sourceModel = sourceEntry.getValue();
+	
+	        getLog().debug( sourcePath.length() == 0 ? "Processing root module as parent"
+	                        : "Processing " + sourcePath + " as a parent." );
+	
+	        final String sourceGroupId = PomHelper.getGroupId( sourceModel );
+	        if ( sourceGroupId == null )
+	        {
+	            getLog().warn( "Module " + sourcePath + " is missing a groupId." );
+	            continue;
+	        }
+	        final String sourceArtifactId = PomHelper.getArtifactId( sourceModel );
+	        if ( sourceArtifactId == null )
+	        {
+	            getLog().warn( "Module " + sourcePath + " is missing an artifactId." );
+	            continue;
+	        }
+	        final String sourceVersion = PomHelper.getVersion( sourceModel );
+	        if ( sourceVersion == null )
+	        {
+	            getLog().warn( "Module " + sourcePath + " is missing a version." );
+	            continue;
+	        }
+	
+	        addFile( files, project, sourcePath );
+	
+	        getLog().debug( "Looking for modules which use "
+	            + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId ) + " as their parent" );
+	
+	        for ( Map.Entry<String, Model> stringModelEntry : PomHelper.getChildModels( reactor, sourceGroupId,
+	                                                                                    sourceArtifactId ).entrySet() )
+	        {
+	            final Map.Entry target = (Map.Entry) stringModelEntry;
+	            final String targetPath = (String) target.getKey();
+	            final Model targetModel = (Model) target.getValue();
+	            final Parent parent = targetModel.getParent();
+	            getLog().debug( "Module: " + targetPath );
+	            if ( sourceVersion.equals( parent.getVersion() ) )
+	            {
+	                getLog().debug( "    parent already is "
+	                    + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId ) + ":" + sourceVersion );
+	            }
+	            else
+	            {
+	                getLog().debug( "    parent is " + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId )
+	                    + ":" + parent.getVersion() );
+	                getLog().debug( "    will become " + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId )
+	                    + ":" + sourceVersion );
+	            }
+	            final boolean targetExplicit = PomHelper.isExplicitVersion( targetModel );
+	            if ( ( updateMatchingVersions || !targetExplicit )
+	                && StringUtils.equals( parent.getVersion(), PomHelper.getVersion( targetModel ) ) )
+	            {
+	                getLog().debug( "    module is "
+	                    + ArtifactUtils.versionlessKey( PomHelper.getGroupId( targetModel ),
+	                                                    PomHelper.getArtifactId( targetModel ) )
+	                    + ":" + PomHelper.getVersion( targetModel ) );
+	                getLog().debug( "    will become "
+	                    + ArtifactUtils.versionlessKey( PomHelper.getGroupId( targetModel ),
+	                                                    PomHelper.getArtifactId( targetModel ) )
+	                    + ":" + sourceVersion );
+	                addChange( PomHelper.getGroupId( targetModel ), PomHelper.getArtifactId( targetModel ),
+	                           PomHelper.getVersion( targetModel ), sourceVersion );
+	                targetModel.setVersion( sourceVersion );
+	            }
+	            else
+	            {
+	                getLog().debug( "    module is "
+	                    + ArtifactUtils.versionlessKey( PomHelper.getGroupId( targetModel ),
+	                                                    PomHelper.getArtifactId( targetModel ) )
+	                    + ":" + PomHelper.getVersion( targetModel ) );
+	            }
+	        }
+	    }
+	}
+
+	private void addFile(Set<File> files, MavenProject project, String relativePath) {
+	    final File moduleDir = new File( project.getBasedir(), relativePath );
+	    final File projectBaseDir = project.getBasedir();
+	
+	    final File moduleProjectFile;
+	
+	    if ( projectBaseDir.equals(moduleDir) )
+	    {
+	        moduleProjectFile = project.getFile();
+	    }
+	    else if ( moduleDir.isDirectory() )
+	    {
+	        moduleProjectFile = new File( moduleDir, "pom.xml" );
+	    }
+	    else
+	    {
+	        // i don't think this should ever happen... but just in case
+	        // the module references the file-name
+	        moduleProjectFile = moduleDir;
+	    }
+	
+	    files.add( moduleProjectFile );
+	}
+
+	/**
+	 * Updates the pom file.
+	 *
+	 * @param pom The pom file to update.
+	 * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong.
+	 * @throws org.apache.maven.plugin.MojoFailureException when things go wrong.
+	 * @throws javax.xml.stream.XMLStreamException when things go wrong.
+	 */
+	protected synchronized void update(ModifiedPomXMLEventReader pom)
+			throws MojoExecutionException, MojoFailureException, XMLStreamException {
+			    ContextualLog log = new DelegatingContextualLog( getLog() );
+			    try
+			    {
+			        Model model = PomHelper.getRawModel( pom );
+			        log.setContext( "Processing " + PomHelper.getGroupId( model ) + ":" + PomHelper.getArtifactId( model ) );
+			
+			        VersionChangerFactory versionChangerFactory = new VersionChangerFactory();
+			        versionChangerFactory.setPom( pom );
+			        versionChangerFactory.setLog( log );
+			        versionChangerFactory.setModel( model );
+			
+			        VersionChanger changer = versionChangerFactory.newVersionChanger( processParent, processProject,
+			                                                                          processDependencies, processPlugins );
+			
+			        for ( VersionChange versionChange : sourceChanges )
+			        {
+			            changer.apply( versionChange );
+			        }
+			    }
+			    catch ( IOException e )
+			    {
+			        throw new MojoExecutionException( e.getMessage(), e );
+			    }
+			    log.clearContext();
+			}
+
+}

--- a/src/main/java/org/codehaus/mojo/versions/SemverMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SemverMojo.java
@@ -1,0 +1,271 @@
+package org.codehaus.mojo.versions;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Updates components of the project's version if it follows the maven-semver format of &lt;major&gt;[.&lt;minor&gt;[.&lt;patch&gt;]][&lt;qualifier&gt;][-SNAPSHOT]<p> 
+ * Major, minor and patch versions are zero or positive integers.<p>
+ * Qualifier is any sequence of characters valid in a Maven version.<p>
+ * -SNAPSHOT can be present or absent is not considered part of the qualifier. <p><p>
+ *
+ * Sample valid maven-semver version numbers :<p>
+ * 0 (major 0, no qualifier, snapshot false)<p>
+ * 0.2-SNAPSHOT (major 0, minor 2, no qualifier, snapshot true)<p>
+ * 2.0.6.RELEASE (major 2, minor 0, patch 6, qualifier ".RELEASE", snapshot false)<p><p>
+ *  
+ * <p><p>
+ * 
+ * New version string can be set at once with the `newVersion` parameter. <p>
+ * Individual version numbers can be set to absolute values by one with the "setMajorVersion", "setMinorVersion", "setPatchVersion" parameters. <p>
+ * Existing individual version numbers can be incremented by one with the "incrementMajorVersion", "incrementMinorVersion", "incrementPatchVersion" parameters. <p>
+ * Snapshot state can be set to an absolute boolean value with the "setSnapshot"parameter. <p>
+ * Qualifier can be set to any absolute string value with the "setQualifier" parameter. <p><p>
+ *    
+ * Minor and patch versions numbers can be added to a version if it did not have them before. <p>
+ * Minor and patch versions numbers can not be _removed_ from a version once set. <p>
+ *
+ * @author Francis Lalonde
+ * @since 2.4.0
+ */
+@Mojo(name = "semver", requiresProject = true, requiresDirectInvocation = true, aggregator = true)
+public class SemverMojo 
+	extends AbstractModuleVersionUpdaterMojo 
+{
+
+	private static final Pattern VERSION_PATTERN = Pattern.compile("0|[1-9]\\d*");
+
+	/**
+	 * The integral new semver version to set.
+	 * Version must be of format &lt;major&gt;[.&lt;minor&gt;[.&lt;patch&gt;]][&lt;qualifier&gt;][-SNAPSHOT]
+	 * For example, 2.4.6-alpha-SNAPSHOT
+	 * Components of this string can be altered by other parameters of the semver goal. 
+	 * If not specified, the project's existing version will be used as a starting point.
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "newVersion") String newVersion;
+
+	/**
+	 * If set to true, forces project version to end with -SNAPSHOT.
+	 * If set to false, removes the -SNAPSHOT at the end of the version if there was one. 
+	 * If left null (default), existing snapshot status is preserved.
+	 * 
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "setSnapshot")
+	private Boolean setSnapshot;
+
+	/**
+	 * If set, updates the version qualifier.
+	 * If left null (default), existing qualifier is preserved.
+	 * 
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "setQualifier")
+	private String setQualifier;
+	
+	/**
+	 * Increment the major version by 1. 
+	 * For example, version "2.4.6" will be changed to "3.4.6".
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "incrementMajorVersion", defaultValue = "false")
+	private boolean incrementMajorVersion;
+
+	/**
+	 * Increment the minor version by 1. 
+	 * For example, version "2.4.6" will be changed to "2.5.6".
+	 * Existing version needs to already have a minor version set or the operation will fail. 
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "incrementMinorVersion", defaultValue = "false")
+	private boolean incrementMinorVersion;
+
+	/**
+	 * Increment the patch version by 1. 
+	 * For example, version "2.4.6" will be changed to "2.4.7".
+	 * Existing version needs to already have a patch version set or the operation will fail. 
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "incrementPatchVersion", defaultValue = "false")
+	private boolean incrementPatchVersion;
+
+	/**
+	 * If set, major version will forcefully be set to the the value. 
+	 * If both this parameter and incrementMajorVersion are set, incrementMajorVersion will be ignored.
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "setMajorVersion")
+	private Integer setMajorVersion;
+
+	/**
+	 * If set, minor version will forcefully be set to the the value. 
+	 * If both this parameter and incrementMinorVersion are set, incrementMinorVersion will be ignored.
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "setMinorVersion")
+	private Integer setMinorVersion;
+
+	/**
+	 * If set, patch version will forcefully be set to the the value. 
+	 * If both this parameter and incrementPatchVersion are set, incrementPatchVersion will be ignored.
+	 *
+	 * @since 2.4.0
+	 */
+	@Parameter(property = "setPatchVersion")
+	private Integer setPatchVersion;
+	
+	private static class MavenSemver 
+	{
+		int major;
+		Integer minor;
+		Integer patch;
+		String qualifier;
+		boolean snapshot;
+
+		static MavenSemver from(String version) throws MojoExecutionException 
+		{
+			MavenSemver semver = new MavenSemver();
+			semver.snapshot = version.endsWith(SNAPSHOT);
+			if (semver.snapshot) {
+				version = version.substring(0, version.length() - SNAPSHOT.length());
+			}
+			
+			Matcher matcher = VERSION_PATTERN.matcher(version);
+			if (!matcher.find()) 
+			{
+				throw new MojoExecutionException("No major version could be parsed, version does not follow Maven semver format <major>[.<minor>[.<patch>]][<qualifier>][-SNAPSHOT]");
+			}
+			
+			semver.major = Integer.parseInt(matcher.group());
+			int qualifierStart = matcher.end();
+
+			if (matcher.find()) 
+			{
+				semver.minor = Integer.parseInt(matcher.group());
+				qualifierStart = matcher.end();
+				
+				// can only have patch version if minor version is also set 
+				if (matcher.find()) 
+				{
+					semver.patch = Integer.parseInt(matcher.group());
+					qualifierStart = matcher.end();
+				}
+			}
+
+			semver.qualifier = version.substring(qualifierStart);
+			return semver;
+		}
+		
+		public String toString() {
+			return String.format("major(%d) minor(%d) patch(%d) qualifier(%s) snapshot(%b)", major, minor, patch, qualifier, snapshot);
+ 
+		}
+
+		public String toVersionString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append(major);
+			if (minor != null) 
+			{
+				sb.append(".").append(minor);
+				
+				// can only have patch version if minor version is also set 
+				if (patch != null) 
+				{
+					sb.append(".").append(patch);
+				}
+			}
+			if (qualifier != null) 
+			{
+				sb.append(qualifier);
+			}
+			if (snapshot) 
+			{
+				sb.append(SNAPSHOT);
+			}
+			return sb.toString();
+		}
+	}
+
+	/**
+	 * Called when this mojo is executed.
+	 *
+	 * @throws org.apache.maven.plugin.MojoExecutionException
+	 *             when things go wrong.
+	 * @throws org.apache.maven.plugin.MojoFailureException
+	 *             when things go wrong.
+	 */
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+		if (getProject().getOriginalModel().getVersion() == null) 
+		{
+			throw new MojoExecutionException("Project version is inherited from parent.");
+		}
+
+		MavenSemver semver = MavenSemver.from(newVersion != null ? newVersion : getVersion());
+		getLog().info("Parsed original semver " + semver);		
+		
+		if (setSnapshot != null) 
+		{
+			semver.snapshot = setSnapshot;
+		}		
+
+		if (setQualifier != null) 
+		{
+			semver.qualifier = setQualifier;
+		}		
+
+		if (setMajorVersion != null) 
+		{
+			semver.major = setMajorVersion;
+		}
+		else if (incrementMajorVersion) 
+		{
+			semver.major++;
+		}
+
+		if (setMinorVersion != null) 
+		{
+			semver.minor = setMinorVersion;
+		}
+		else if (incrementMinorVersion) 
+		{
+			if (semver.minor == null) 
+			{
+				throw new MojoExecutionException("No minor version to increment.");
+			}
+			semver.minor++;
+		}
+
+		if (setPatchVersion != null) 
+		{
+			if (semver.minor == null) 
+			{
+				throw new MojoExecutionException("Cannot set patch version without minor version.");
+			}
+			semver.patch = setPatchVersion;
+		}
+		else if (incrementPatchVersion) 
+		{
+			if (semver.minor == null) 
+			{
+				throw new MojoExecutionException("No patch version to increment.");
+			}
+			semver.patch++;
+		}
+
+		setVersion(semver.toVersionString());
+	}
+
+}

--- a/src/main/java/org/codehaus/mojo/versions/SetMojo.java
+++ b/src/main/java/org/codehaus/mojo/versions/SetMojo.java
@@ -1,57 +1,13 @@
 package org.codehaus.mojo.versions;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.regex.Pattern;
 
-import javax.xml.stream.XMLStreamException;
-
-import org.apache.maven.artifact.ArtifactUtils;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.Parent;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.mojo.versions.api.PomHelper;
-import org.codehaus.mojo.versions.change.VersionChange;
-import org.codehaus.mojo.versions.change.VersionChanger;
-import org.codehaus.mojo.versions.change.VersionChangerFactory;
-import org.codehaus.mojo.versions.ordering.ReactorDepthComparator;
-import org.codehaus.mojo.versions.rewriting.ModifiedPomXMLEventReader;
-import org.codehaus.mojo.versions.utils.ContextualLog;
-import org.codehaus.mojo.versions.utils.DelegatingContextualLog;
-import org.codehaus.mojo.versions.utils.RegexUtils;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
 import org.codehaus.plexus.util.StringUtils;
@@ -65,82 +21,15 @@ import org.codehaus.plexus.util.StringUtils;
  */
 @Mojo (name="set", requiresProject = true, requiresDirectInvocation = true, aggregator = true)
 public class SetMojo
-    extends AbstractVersionsUpdaterMojo
+    extends AbstractModuleVersionUpdaterMojo
 {
-
-    private static final String SNAPSHOT = "-SNAPSHOT";
 
     /**
      * The new version number to set.
      *
      * @since 1.0-beta-1
      */
-    @Parameter(property = "newVersion")
-    private String newVersion;
-
-    /**
-     * The groupId of the dependency/module to update.
-     *
-     * @since 1.2
-     */
-    @Parameter(property = "groupId", defaultValue = "${project.groupId}")
-    private String groupId;
-
-    /**
-     * The artifactId of the dependency/module to update.
-     *
-     * @since 1.2
-     */
-    @Parameter(property = "artifactId", defaultValue = "${project.artifactId}")
-    private String artifactId;
-
-    /**
-     * The version of the dependency/module to update.
-     *
-     * @since 1.2
-     */
-    @Parameter(property = "oldVersion", defaultValue = "${project.version}")
-    private String oldVersion;
-
-    /**
-     * Whether matching versions explicitly specified (as /project/version) in child modules should be updated.
-     *
-     * @since 1.3
-     */
-    @Parameter(property = "updateMatchingVersions", defaultValue = "true")
-    private Boolean updateMatchingVersions;
-
-    /**
-     * Whether to process the parent of the project. If not set will default to true.
-     *
-     * @since 1.3
-     */
-    @Parameter(property = "processParent", defaultValue = "true")
-    private boolean processParent;
-
-    /**
-     * Whether to process the project version. If not set will default to true.
-     *
-     * @since 1.3
-     */
-    @Parameter(property = "processProject", defaultValue = "true")
-    private boolean processProject;
-
-    /**
-     * Whether to process the dependencies section of the project. If not set will default to true.
-     *
-     * @since 1.3
-     */
-    @Parameter(property = "processDependencies", defaultValue = "true")
-    private boolean processDependencies;
-
-    /**
-     * Whether to process the plugins section of the project. If not set will default to true.
-     *
-     * @since 1.3
-     */
-    @Parameter(property = "processPlugins", defaultValue = "true")
-    private boolean processPlugins;
+    @Parameter(property = "newVersion") String newVersion;
 
     /**
      * Component used to prompt for input
@@ -167,19 +56,6 @@ public class SetMojo
     private boolean nextSnapshot;
 
     /**
-     * The changes to module coordinates. Guarded by this.
-     */
-    private final transient List<VersionChange> sourceChanges = new ArrayList<VersionChange>();
-
-    private synchronized void addChange( String groupId, String artifactId, String oldVersion, String newVersion )
-    {
-        if ( !newVersion.equals( oldVersion ) )
-        {
-            sourceChanges.add( new VersionChange( groupId, artifactId, oldVersion, newVersion ) );
-        }
-    }
-
-    /**
      * Called when this mojo is executed.
      *
      * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong.
@@ -188,10 +64,6 @@ public class SetMojo
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
-        if ( updateMatchingVersions == null )
-        {
-            updateMatchingVersions = Boolean.TRUE;
-        }
 
         if ( getProject().getOriginalModel().getVersion() == null )
         {
@@ -266,221 +138,7 @@ public class SetMojo
                 + "property (that is -DnewVersion=... on the command line) or run in interactive mode" );
         }
 
-        try
-        {
-            final MavenProject project =
-                PomHelper.getLocalRoot( projectBuilder, getProject(), localRepository, null, getLog() );
-
-            getLog().info( "Local aggregation root: " + project.getBasedir() );
-            Map<String, Model> reactorModels = PomHelper.getReactorModels( project, getLog() );
-            final SortedMap<String, Model> reactor =
-                new TreeMap<String, Model>( new ReactorDepthComparator( reactorModels ) );
-            reactor.putAll( reactorModels );
-
-            // set of files to update
-            final Set<File> files = new LinkedHashSet<File>();
-
-            getLog().info( "Processing change of " + groupId + ":" + artifactId + ":" + oldVersion + " -> "
-                + newVersion );
-            Pattern groupIdRegex =
-                Pattern.compile( RegexUtils.convertWildcardsToRegex( fixNullOrEmpty( groupId, "*" ), true ) );
-            Pattern artifactIdRegex =
-                Pattern.compile( RegexUtils.convertWildcardsToRegex( fixNullOrEmpty( artifactId, "*" ), true ) );
-            Pattern oldVersionIdRegex =
-                Pattern.compile( RegexUtils.convertWildcardsToRegex( fixNullOrEmpty( oldVersion, "*" ), true ) );
-            boolean found = false;
-            for ( Model m : reactor.values() )
-            {
-                final String mGroupId = PomHelper.getGroupId( m );
-                final String mArtifactId = PomHelper.getArtifactId( m );
-                final String mVersion = PomHelper.getVersion( m );
-                if ( groupIdRegex.matcher( mGroupId ).matches() && artifactIdRegex.matcher( mArtifactId ).matches()
-                    && oldVersionIdRegex.matcher( mVersion ).matches() && !newVersion.equals( mVersion ) )
-                {
-                    found = true;
-                    // if the change is not one we have swept up already
-                    applyChange( project, reactor, files, mGroupId, m.getArtifactId(),
-                                 StringUtils.isBlank( oldVersion ) || "*".equals( oldVersion ) ? "" : m.getVersion() );
-                }
-            }
-            if ( !found && RegexUtils.getWildcardScore(groupId) == 0
-            		&& RegexUtils.getWildcardScore(artifactId) == 0
-            		&& RegexUtils.getWildcardScore(oldVersion) == 0 )
-            {
-                applyChange( project, reactor, files, groupId, artifactId, oldVersion );
-            }
-
-            // now process all the updates
-            for ( File file : files )
-            {
-                process( file );
-            }
-
-        }
-        catch ( IOException e )
-        {
-            throw new MojoExecutionException( e.getMessage(), e );
-        }
-    }
-
-    private static String fixNullOrEmpty( String value, String defaultValue )
-    {
-        return StringUtils.isBlank( value ) ? defaultValue : value;
-    }
-
-    private void applyChange( MavenProject project, SortedMap<String, Model> reactor, Set<File> files, String groupId,
-                              String artifactId, String oldVersion )
-    {
-
-        getLog().debug( "Applying change " + groupId + ":" + artifactId + ":" + oldVersion + " -> " + newVersion );
-        // this is a triggering change
-        addChange( groupId, artifactId, oldVersion, newVersion );
-        // now fake out the triggering change
-
-        final Map.Entry<String, Model> current = PomHelper.getModelEntry( reactor, groupId, artifactId );
-        current.getValue().setVersion( newVersion );
-
-        addFile( files, project, current.getKey() );
-
-        for ( Map.Entry<String, Model> sourceEntry : reactor.entrySet() )
-        {
-            final String sourcePath = sourceEntry.getKey();
-            final Model sourceModel = sourceEntry.getValue();
-
-            getLog().debug( sourcePath.length() == 0 ? "Processing root module as parent"
-                            : "Processing " + sourcePath + " as a parent." );
-
-            final String sourceGroupId = PomHelper.getGroupId( sourceModel );
-            if ( sourceGroupId == null )
-            {
-                getLog().warn( "Module " + sourcePath + " is missing a groupId." );
-                continue;
-            }
-            final String sourceArtifactId = PomHelper.getArtifactId( sourceModel );
-            if ( sourceArtifactId == null )
-            {
-                getLog().warn( "Module " + sourcePath + " is missing an artifactId." );
-                continue;
-            }
-            final String sourceVersion = PomHelper.getVersion( sourceModel );
-            if ( sourceVersion == null )
-            {
-                getLog().warn( "Module " + sourcePath + " is missing a version." );
-                continue;
-            }
-
-            addFile( files, project, sourcePath );
-
-            getLog().debug( "Looking for modules which use "
-                + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId ) + " as their parent" );
-
-            for ( Map.Entry<String, Model> stringModelEntry : PomHelper.getChildModels( reactor, sourceGroupId,
-                                                                                        sourceArtifactId ).entrySet() )
-            {
-                final Map.Entry target = (Map.Entry) stringModelEntry;
-                final String targetPath = (String) target.getKey();
-                final Model targetModel = (Model) target.getValue();
-                final Parent parent = targetModel.getParent();
-                getLog().debug( "Module: " + targetPath );
-                if ( sourceVersion.equals( parent.getVersion() ) )
-                {
-                    getLog().debug( "    parent already is "
-                        + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId ) + ":" + sourceVersion );
-                }
-                else
-                {
-                    getLog().debug( "    parent is " + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId )
-                        + ":" + parent.getVersion() );
-                    getLog().debug( "    will become " + ArtifactUtils.versionlessKey( sourceGroupId, sourceArtifactId )
-                        + ":" + sourceVersion );
-                }
-                final boolean targetExplicit = PomHelper.isExplicitVersion( targetModel );
-                if ( ( updateMatchingVersions || !targetExplicit )
-                    && StringUtils.equals( parent.getVersion(), PomHelper.getVersion( targetModel ) ) )
-                {
-                    getLog().debug( "    module is "
-                        + ArtifactUtils.versionlessKey( PomHelper.getGroupId( targetModel ),
-                                                        PomHelper.getArtifactId( targetModel ) )
-                        + ":" + PomHelper.getVersion( targetModel ) );
-                    getLog().debug( "    will become "
-                        + ArtifactUtils.versionlessKey( PomHelper.getGroupId( targetModel ),
-                                                        PomHelper.getArtifactId( targetModel ) )
-                        + ":" + sourceVersion );
-                    addChange( PomHelper.getGroupId( targetModel ), PomHelper.getArtifactId( targetModel ),
-                               PomHelper.getVersion( targetModel ), sourceVersion );
-                    targetModel.setVersion( sourceVersion );
-                }
-                else
-                {
-                    getLog().debug( "    module is "
-                        + ArtifactUtils.versionlessKey( PomHelper.getGroupId( targetModel ),
-                                                        PomHelper.getArtifactId( targetModel ) )
-                        + ":" + PomHelper.getVersion( targetModel ) );
-                }
-            }
-        }
-    }
-
-    private void addFile( Set<File> files, MavenProject project, String relativePath )
-    {
-        final File moduleDir = new File( project.getBasedir(), relativePath );
-        final File projectBaseDir = project.getBasedir();
-
-        final File moduleProjectFile;
-
-        if ( projectBaseDir.equals(moduleDir) )
-        {
-            moduleProjectFile = project.getFile();
-        }
-        else if ( moduleDir.isDirectory() )
-        {
-            moduleProjectFile = new File( moduleDir, "pom.xml" );
-        }
-        else
-        {
-            // i don't think this should ever happen... but just in case
-            // the module references the file-name
-            moduleProjectFile = moduleDir;
-        }
-
-        files.add( moduleProjectFile );
-    }
-
-    /**
-     * Updates the pom file.
-     *
-     * @param pom The pom file to update.
-     * @throws org.apache.maven.plugin.MojoExecutionException when things go wrong.
-     * @throws org.apache.maven.plugin.MojoFailureException when things go wrong.
-     * @throws javax.xml.stream.XMLStreamException when things go wrong.
-     */
-    protected synchronized void update( ModifiedPomXMLEventReader pom )
-        throws MojoExecutionException, MojoFailureException, XMLStreamException
-    {
-        ContextualLog log = new DelegatingContextualLog( getLog() );
-        try
-        {
-            Model model = PomHelper.getRawModel( pom );
-            log.setContext( "Processing " + PomHelper.getGroupId( model ) + ":" + PomHelper.getArtifactId( model ) );
-
-            VersionChangerFactory versionChangerFactory = new VersionChangerFactory();
-            versionChangerFactory.setPom( pom );
-            versionChangerFactory.setLog( log );
-            versionChangerFactory.setModel( model );
-
-            VersionChanger changer = versionChangerFactory.newVersionChanger( processParent, processProject,
-                                                                              processDependencies, processPlugins );
-
-            for ( VersionChange versionChange : sourceChanges )
-            {
-                changer.apply( versionChange );
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new MojoExecutionException( e.getMessage(), e );
-        }
-        log.clearContext();
+        setVersion(newVersion);
     }
 
 }


### PR DESCRIPTION
Updates components of the project's version if it follows the maven-semver format of &lt;major&gt;[.&lt;minor&gt;[.&lt;patch&gt;]][&lt;qualifier&gt;][-SNAPSHOT]

Major, minor and patch versions are zero or positive integers.
Qualifier is any sequence of characters valid in a Maven version.
-SNAPSHOT can be present or absent is not considered part of the qualifier.

Sample valid maven-semver version numbers :
- 0 (major 0, no qualifier, snapshot false)
- 0.2-SNAPSHOT (major 0, minor 2, no qualifier, snapshot true)
- 2.0.6.RELEASE (major 2, minor 0, patch 6, qualifier ".RELEASE", snapshot false)

New version string can be set at once with the `newVersion` parameter.
Individual version numbers can be set to absolute values by one with the `setMajorVersion`, `setMinorVersion`, `setPatchVersion` parameters.
Existing individual version numbers can be incremented by one with the `incrementMajorVersion`, `incrementMinorVersion`, `incrementPatchVersion` parameters.
Snapshot state can be set to an absolute boolean value with the `setSnapshot`parameter.
Qualifier can be set to any absolute string value with the `setQualifier` parameter.

Minor and patch versions numbers can be added to a version if it did not have them before.
Minor and patch versions numbers can not be _removed_ from a version once set.